### PR TITLE
Fixed torch.exp inf error(measurements_loss)

### DIFF
--- a/configs/cmd_parser.py
+++ b/configs/cmd_parser.py
@@ -240,6 +240,10 @@ def parse_config(argv=None):
                         default=False,
                         type=lambda x: x.lower() in ['true', '1'],
                         help='Whether to use the left and right hand poses from the presetend pose')
+    parser.add_argument('--weight_above_150',
+                        default=False,
+                        type=lambda x: x.lower() in ['true', '1'],
+                        help='Whether to multiply a factor to prevent measurements_loss exploding')
 
 
     # optimizer flags

--- a/lib/core/losses.py
+++ b/lib/core/losses.py
@@ -279,7 +279,7 @@ class SMPLifyXMCLoss(nn.Module):
                 f_mass = fitted_measurements['mass']
                 # shape loss
                 measurements_loss = torch.exp(100*(abs(f_height-gt_height))) + \
-                            torch.exp(abs(f_mass-gt_weight))
+                            torch.exp(abs(f_mass-gt_weight)/5)
                 shape_loss = (shape_prior_loss + measurements_loss) * self.shape_weight
             else:
                 shape_loss = shape_prior_loss * self.shape_weight

--- a/lib/core/losses.py
+++ b/lib/core/losses.py
@@ -113,6 +113,7 @@ class SMPLifyXMCLoss(nn.Module):
         self.J_regressor = body_model.J_regressor
 
         self.shape_prior = shape_prior
+        self.weight_above_150 = kwargs.pop('weight_above_150')
 
         self.use_hands = use_hands
         if self.use_hands:
@@ -278,8 +279,13 @@ class SMPLifyXMCLoss(nn.Module):
                 f_height = fitted_measurements['height']
                 f_mass = fitted_measurements['mass']
                 # shape loss
-                measurements_loss = torch.exp(100*(abs(f_height-gt_height))) + \
-                            torch.exp(abs(f_mass-gt_weight)/5)
+                measurements_loss = None
+                if self.weight_above_150:
+                    measurements_loss = torch.exp(100 * (abs(f_height - gt_height))) + \
+                                        torch.exp(abs(f_mass - gt_weight) / 5)
+                else:
+                    measurements_loss = torch.exp(100*(abs(f_height-gt_height))) + \
+                                torch.exp(abs(f_mass-gt_weight))
                 shape_loss = (shape_prior_loss + measurements_loss) * self.shape_weight
             else:
                 shape_loss = shape_prior_loss * self.shape_weight


### PR DESCRIPTION
- When I tried with weight over 150kg, measurements_loss became inf. So I couldn't fit with the person.
- I am not sure this is the best way to fix. But when I tried another method like [log1pexp](https://stackoverflow.com/questions/60903821/how-to-prevent-inf-while-working-with-exponential) it doesn't have an effect
- test data : https://drive.google.com/file/d/1Tea9d5VPuD0LTq19mPJlCm-MSgIlJyi1/view?usp=sharing
